### PR TITLE
WIN32 & MSVC preprocessor issue

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -47,13 +47,13 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 // Open files in binary mode
 #include <fcntl.h> /*  _O_BINARY */
 #include <windows.h>
 #include <dbghelp.h>
 #include <time.h>
-#ifdef MSVC
+#ifdef _MSC_VER
 #undef _fmode
 int _fmode = _O_BINARY;
 #else
@@ -410,7 +410,7 @@ int main( int argc, char *argv[] )
 #endif
 
   QgsDebugMsg( QString( "Starting qgis main" ) );
-#ifdef WIN32  // Windows
+#ifdef _WIN32  // Windows
 #ifdef _MSC_VER
   _set_fmode( _O_BINARY );
 #else //MinGW

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -41,6 +41,9 @@
 #include <qglobal.h>
 
 #include <cmath>
+#ifdef _WIN32
+#include <math.h>
+#endif
 #include <cstring>
 #include <cfloat>
 
@@ -82,7 +85,13 @@ namespace pal
       , repeatDist( 0.0 )
       , alwaysShow( false )
   {
-    assert( finite( lx ) && finite( ly ) );
+// microsoft vs 2010+ has a different version and name.
+// cmath and math.h are needed.
+#ifdef _WIN32
+    assert( _finite( lx ) && _finite( ly ) );
+#else
+	   assert( finite( lx ) && finite( ly ) );
+#endif
 
     uid = new char[strlen( geom_id ) +1];
     strcpy( uid, geom_id );

--- a/src/providers/grass/qgsgrass.h
+++ b/src/providers/grass/qgsgrass.h
@@ -270,7 +270,8 @@ class QgsGrass
     // set environment variable
     static GRASS_LIB_EXPORT void putEnv( QString name, QString value );
 
-#if defined(WIN32)
+// bug: #if defined() incorrect syntax.
+#ifdef _WIN32
     static GRASS_LIB_EXPORT QString shortPath( const QString &path );
 #endif
 


### PR DESCRIPTION
While building under VS 2010(win7), I found that some preprocessor is not correct. I was getting 100+ errors for non-windows includes being used. The following fixed the issues.

_WIN32, instead of WIN32
MSVC does not work, but _MS_VER will give a value for the version of VC being used. It will return 0 if not VC.
